### PR TITLE
修复 _getLocalMutes 逻辑顺序导致的断点续传失效问题

### DIFF
--- a/mute_wumao.user.js
+++ b/mute_wumao.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Twitter/X Glass Great Wall
 // @namespace    https://github.com/anonym-g/X-Accounts-Based-in-China-Auto-Mute
-// @version      1.2.4
+// @version      1.2.5
 // @description  Auto-Mute CCP troll X (Twitter) accounts. 自动屏蔽 X (Twitter) 五毛账号。
 // @author       OpenSource
 // @match        https://x.com/*
@@ -504,6 +504,23 @@
 
         async _getLocalMutes(csrf) {
             this.ui.log("🔎 正在校验已屏蔽列表缓存...");
+
+            // 只要有断点，直接续传，无视指纹校验，防止被 clearCache 清除
+            const savedCursor = Storage.get(Config.CACHE_KEYS.TEMP_CURSOR);
+            const savedList = Storage.get(Config.CACHE_KEYS.TEMP_LIST, []);
+
+            // 只要 cursor 有效且有临时数据，就认为是中断任务
+            if (savedCursor && savedCursor !== "0" && savedCursor !== 0 && savedList.length > 0) {
+                this.ui.log("⚠️ 检测到中断任务。正在断点续传...");
+
+                // fetchFullMuteList 内部会断点续传
+                const fullSet = await this.api.fetchFullMuteList(csrf, null,
+                    (count) => this.ui.updateProgress(0, `📥 续传中: ${count} 人`)
+                );
+
+                await this.saveToCache(fullSet);
+                return fullSet;
+            }
 
             // 1. 获取最新屏蔽列表头部 (API)
             let liveHeadUsernames = [];


### PR DESCRIPTION
# Problem
在原有 _getLocalMutes 函数中，断点检测逻辑位于缓存指纹校验后。当用户因触发 Twitter API 429 限制而中断任务时，本地缓存是不完整的。这会导致再次运行时指纹校验失败，进而执行 Storage.clearCache()。这一步会清除刚刚保存的断点数据，导致每次都从头拉取名单，陷入“拉取 -> 429 -> 存断点 -> 刷新 -> 误删断点 -> 从头拉取”的死循环。
# Solution
调整了 _getLocalMutes 的逻辑顺序。在函数开头优先检查是否存在断点数据。如果存在断点，直接调用 fetchFullMuteList 进行续传，跳过后续的指纹校验和清除缓存操作。 
# Related Issues
#3 #4 遇到的应该就是这个问题